### PR TITLE
Did a general clean-up of the whole wiki

### DIFF
--- a/docs/block/falling.md
+++ b/docs/block/falling.md
@@ -6,18 +6,18 @@ Type ID: `block:falling`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block/fence_gates.md
+++ b/docs/block/fence_gates.md
@@ -6,18 +6,18 @@ Type ID: `block:fence_gate`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block/fences.md
+++ b/docs/block/fences.md
@@ -6,18 +6,18 @@ Type ID: `block:fence`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block/generic.md
+++ b/docs/block/generic.md
@@ -6,18 +6,18 @@ Type ID: `block:generic`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block/slabs.md
+++ b/docs/block/slabs.md
@@ -6,18 +6,18 @@ Type ID: `block:slab`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 

--- a/docs/block/stairs.md
+++ b/docs/block/stairs.md
@@ -4,20 +4,20 @@ Type ID: `block:stairs`
 
 ### Fields
 
-   Field           | Type | Default | Description
--------------------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+   Field   | Type | Default | Description
+-----------|------|---------|-------------
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block/walls.md
+++ b/docs/block/walls.md
@@ -6,18 +6,18 @@ Type ID: `block:wall`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`material` | [Material](../data_types/materials.md) | *manditory* | An Object that determines some behaviours of the block.
-`mechanics` | [Array](../data_types/array.md) of [Mechanic Type](../mechanic_types.md) | *optional* | A list of [Mechanic Type](../mechanic_types.md) that the block will have.
-`render_layer` | [Render Layer](../data_types/render_layer.md) | *Solid* | The blocks render layer `ewsagsfv`.
+`material` | [Material](../data_types/materials.md) | | An Object that determines some behaviours of the block.
+`mechanics` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | The namespace and IDs of the Block Mechanics this block will have.
+`render_layer` | [Render Layer](../data_types/render_layer.md) | `"solid"` | The blocks render layer `ewsagsfv`.
 `block_sound_group` | [Block Sound Group](../data_types/sounds.md) | *optional* | The sounds related to the player moving and walking on the block.
-`collidable` | [Boolean](../data_types/boolean.md) | *true* | Wether you can walk through the block or not
-`transparent` | [Boolean](../data_types/boolean.md) | *false* | Sets the block to be `nonOpaque`.
-`hardness` | [Integer](../data_types/integer.md) | *3* | How long it takes to break (3 is stone 50 is obsidian).
-`slipperiness` | [Float](../data_types/float.md) | *0.6f* | How slippery the block is to walk on.
-`resistance` | [Integer](../data_types/integer.md) | *3* | How immune to explosions the block is (3 is stone, 1500 is obsidian).
-`luminance` | [Integer](../data_types/integer.md) | *0* | The light level that the block gives off.
-`requires_tool` | [boolean](../data_types/boolean.md) | false | Should the block require a tool to break?
-`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table for the block that is dropped when this block is broken.
+`collidable` | [Boolean](../data_types/boolean.md) | `true` | Whether you can walk through the block or not.
+`transparent` | [Boolean](../data_types/boolean.md) | `false` | If set to true, makes the block `nonOpaque`.
+`hardness` | [Integer](../data_types/integer.md) | `3` | How long the block takes to break (3 is stone 50 is obsidian).
+`slipperiness` | [Float](../data_types/float.md) | `0.6` | How slippery the block is to walk on.
+`resistance` | [Integer](../data_types/integer.md) | `3` | Short for "Blast Resistance". Defines how resistant to explosions the block will be (3 is stone, 1500 is obsidian).
+`luminance` | [Integer](../data_types/integer.md) | `0` | The light level that the block gives off.
+`requires_tool` | [boolean](../data_types/boolean.md) | `false` | If set to true, the block will require a specific tool to be broken.
+`loot_table` | [Identifier](../data_types/identifier.md) | *optional* | The loot table that the block uses to define what to drop when broken.
 `block_item` | [Block Item](../items/generic.md) | *optional* | An object for creating an item for the block.
 
 ### Example Code

--- a/docs/block_actions/change_resource.md
+++ b/docs/block_actions/change_resource.md
@@ -1,7 +1,7 @@
 # Change Resource
 
 !!! note
-	This action will only work on ccpacks blocks with the [Resource](../mechanic_types/resource.md) Mechanic.
+	This action will only work on CCPacks blocks with the [Resource](../mechanic_types/resource.md) Mechanic.
 
 Changes a blocks resource, by either adding or setting.
 
@@ -11,9 +11,9 @@ Type ID: `ccpacks:change_resource`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`resource` | [Identifier](../data_types/identifier.md) |  | ID of the mechanic type that defines the resource. Must be a [Resource](../mechanic_types/resource.md) which exists on the block.
-`change` | [Integer](../data_types/integer.md) |  | This value will be added to the resource.
-`operation` | [String](../data_types/string.md) | "add" | Determines if the action should add or set the value of the resource. Accepts `"add"` or `"set"`.
+`resource` | [Identifier](../data_types/identifier.md) | | ID of the mechanic type that defines the resource. Must be a [Resource (Mechanic Type)](../mechanic_types/resource.md) which exists on the block.
+`change` | [Integer](../data_types/integer.md) | | This value will be added to the resource.
+`operation` | [String](../data_types/string.md) | `"add"` | Determines if the action should add or set the value of the resource. Accepts `"add"` or `"set"`.
 
 ### Example
 ```json
@@ -21,7 +21,7 @@ Field  | Type | Default | Description
     "type": "ccpacks:change_resource",
     "resource": "example_pack:fuel",
     "change": 1,
-	"operation": add
+	  "operation": "add"
 }
 ```
-This action adds 1 to the `example_pack:fuel` [Resource](../mechanic_types/resource.md) power. (`data\example_pack\mechanics\fuel.json`)
+This action adds 1 to the `example_pack:fuel` [Resource](../mechanic_types/resource.md) mechanic. (`data\example_pack\mechanics\fuel.json`)

--- a/docs/block_actions/trigger_mechanic.md
+++ b/docs/block_actions/trigger_mechanic.md
@@ -1,9 +1,9 @@
 # Trigger Mechanic
 
 !!! note
-	This action will only work on ccpacks blocks with the [Triggerable](../mechanic_types/triggerable.md) Mechanic.
+	This action will only work on CCPacks blocks with the [Triggerable (Mechanic Types)](../mechanic_types/triggerable.md) Mechanic.
 
-Triggers a block's mechanic. Useful with the [Offset](https://origins.readthedocs.io/en/latest/types/block_action_types/offset/) meta action. 
+Triggers a block's mechanic. Useful with the [Offset (Block Action Type)](https://origins.readthedocs.io/en/latest/types/block_action_types/offset/) meta action.
 
 Type ID: `ccpacks:trigger_mechanic`
 
@@ -16,7 +16,7 @@ Field  | Type | Default | Description
 ### Example
 ```json
 "block_action": {
-  	"type": "ccpacks:trigger_mechanic",
+	"type": "ccpacks:trigger_mechanic",
 	"mechanic": "example_pack:smelt"
 }
 ```

--- a/docs/block_conditions/exposed_to_sun.md
+++ b/docs/block_conditions/exposed_to_sun.md
@@ -6,11 +6,12 @@ Type ID: `ccpacks:exposed_to_sun`
 
 ### Fields
 
-This condition has no fields.
+_None_
 
 ### Example
 ```json
 "block_condition": {
-    "type": "ccpacks:exposed_to_sun"
+    "type": "ccpacks:exposed_to_sun",
+    "inverted": true
 }
 ```

--- a/docs/block_conditions/resource.md
+++ b/docs/block_conditions/resource.md
@@ -1,7 +1,7 @@
 # Resource
 
 !!! note
-	This condition will only work on ccpacks blocks with the [Resource](../mechanic_types/resource.md) Mechanic.
+	This condition will only work on CCPacks blocks with the [Resource (Mechanic Type)](../mechanic_types/resource.md).
 
 Checks the value of a power that uses the [Resource (Mechanic Type)](../mechanic_types/resource.md).
 
@@ -11,9 +11,9 @@ Type ID: `ccpacks:resource`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`resource` | [Identifier](../data_types/identifier.md) | *manditory* | The namespace ID of a mechanic that will be evaluated.
-`comparison` | [Comparison](../data_types/comparison.md) | "==" | How the value of the mechanic that will be evaluated should be compared to the specified value.
-`compare_to` | [Integer](../data_types/integer.md) | 0 | The value to compare the value of the mechanic that will be evaluated to.
+`resource` | [Identifier](../data_types/identifier.md) | | The namespace ID of a mechanic that will be evaluated.
+`comparison` | [Comparison](../data_types/comparison.md) | `"=="` | How the value of the mechanic that will be evaluated should be compared to the specified value.
+`compare_to` | [Integer](../data_types/integer.md) | `0` | The value to compare the value of the mechanic that will be evaluated to.
 
 ### Example
 ```json

--- a/docs/choice_json.md
+++ b/docs/choice_json.md
@@ -26,4 +26,4 @@ Field  | Type | Default | Description
     "description": "You can harness mana to use in a staff!"
 }
 ```
-This example choice adds  with a `minecraft:diamond` as its icon.
+This example choice adds with a `minecraft:diamond` as its icon.

--- a/docs/data_types.md
+++ b/docs/data_types.md
@@ -15,7 +15,7 @@ Data types are used everywhere in the JSON files. Every field in a JSON has to h
 
 * [Colour](data_types/colour.md)
 * [Damage Source](data_types/damage_source.md)
-* [Hud Renderer](data_types/hud_render.md)
+* [Hud Render](data_types/hud_render.md)
 * [Identifier](data_types/identifier.md)
 * [Item Groups](data_types/item_groups.md)
 * [Item Stack](data_types/item_stack.md)

--- a/docs/data_types/array.md
+++ b/docs/data_types/array.md
@@ -22,10 +22,10 @@ An array of [Strings](string.md).
 ```json
 "conditions": [
     {
-        "type": "origins:on_fire"
+        "type": "apoli:on_fire"
     },
     {
-        "type": "origins:sprinting"
+        "type": "apoli:sprinting"
     }
 ]
 ```

--- a/docs/data_types/colour.md
+++ b/docs/data_types/colour.md
@@ -1,8 +1,11 @@
-# Colour
+# Colour Holder
 
 [Data Type](../data_types.md).
 
 An [Object](object.md) that holds RGBA values
+
+!!! note
+		The name of this Data Type is "colour", not "color"! Be careful not to misspell it!
 
 ### Fields:
 
@@ -34,4 +37,4 @@ This definition results in a red colour.
 	"alpha": 0.5
 }
 ```
-This definition results in a slightly transparent blue colour.
+This definition results in a blue colour with half opacity.

--- a/docs/data_types/hud_render.md
+++ b/docs/data_types/hud_render.md
@@ -8,11 +8,11 @@ An [Object](object.md) used to define how a stat bar should be rendered.
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`should_render` | [Boolean](boolean.md) | true | Whether the bar should be visible or not.
-`sprite_location` | [Identifier](identifier.md) | "apoli:textures/gui/resource_bar.png" | The path to the file in the assets which contains what the bar looks like. The base mod doesnt include any bars, but you can create your own using resource packs.
-`bar_index` | [Integer](integer.md) | 0 | The indexed position of the bar on the sprite to use. Please note that indexes start at 0.
+`should_render` | [Boolean](boolean.md) | `true` | Whether the bar should be visible or not.
+`sprite_location` | [Identifier](identifier.md) | `"ccpacks:textures/gui/resource_bar.png"` | The path to the file in the assets which contains what the bar looks like. The base mod doesn't include any bars, but you can create your own using Resource Packs.
+`bar_index` | [Integer](integer.md) | `0` | The indexed position of the bar on the sprite to use. Please note that indexes start at 0.
 `condition` | [Entity Condition](https://origins.readthedocs.io/en/latest/types/entity_condition_types/) | _optional_ | If set (and `should_render` is true), the bar will only display when the entity with the power fulfills this condition.
-`side` | [String](string.md) | `"right"` | Determines which side of the players hud the bar appears on. Can be `"left"` or `"right"`.
+`side` | [String](string.md) | `"right"` | Determines which side of the players HUD the bar appears on. Can be `"left"` or `"right"`.
 
 ### Examples:
 

--- a/docs/data_types/identifier.md
+++ b/docs/data_types/identifier.md
@@ -16,7 +16,7 @@ Read more here: [Minecraft Fandom Wiki: Namespaced ID](https://minecraft.fandom.
 
 ```json
 {
-	"type": "origins:block",
+	"type": "apoli:block",
 	"block": "iron_ore"
 }
 ```
@@ -26,9 +26,9 @@ A `block` identifier specifying iron ore. The namespace is not specified, thus d
 
 ```json
 {
-	"type": "origins:origin",
-	"origin": "origins-classes:stealth"
+	"type": "apoli:power",
+	"power": "test:example_power"
 }
 ```
 
-An `origin` identifier specifying the stealth status effect added by the Origins: Classes add-on.
+A `power` identifier specifying the `test:example_power` power (located on `data/test/powers/example_power.json`).

--- a/docs/data_types/integer.md
+++ b/docs/data_types/integer.md
@@ -8,8 +8,8 @@ A whole number (integer number), like 3 or -1. Numbers such as 0.3 or 5.5 are no
 ### Examples
 
 ```json
-{	
-	"type":"origins:set_on_fire",
+{
+	"type":"ccpacks:set_on_fire",
 	"duration": 3
 }
 ```

--- a/docs/data_types/item_power.md
+++ b/docs/data_types/item_power.md
@@ -10,18 +10,18 @@ An [Object](object.md) used to define how a stat bar should be rendered.
 
 Field  |      Type         | Default | Description
 -------|-------------------|---------|-------------
-`power`  | [Power](../data_types/float.md) | *mandetory* | The ID for the power to grant.
-`slot`| [Equipment Slot](../data_types/float.md) | "mainhand" | The slot that power is active in.
-`hidden` | [Boolean](../data_types/float.md) | false | Wether the item shows that it has this power.
-`negative`| [Boolean](../data_types/float.md) | false | Changes wether the tooltip is blue, or red.
+`power`  | [Power](../data_types/float.md) | | The ID for the power to grant.
+`slot`| [Equipment Slot](../data_types/float.md) | `"mainhand"` | The slot that power is active in.
+`hidden` | [Boolean](../data_types/float.md) | `false` | Whether the item shows that it has this power.
+`negative`| [Boolean](../data_types/float.md) | `false` | Changes whether the tooltip is blue, or red.
 
 ####Trinket Powers:
 
 Field  |      Type         | Default | Description
 -------|-------------------|---------|-------------
-`power`  | [Power](../data_types/float.md) | *mandetory* | The ID for the power to grant.
-`hidden` | [Boolean](../data_types/float.md) | false | Wether the item shows that it has this power.
-`negative`| [Boolean](../data_types/float.md) | false | Changes wether the tooltip is blue, or red.
+`power`  | [Power](../data_types/float.md) | | The ID for the power to grant.
+`hidden` | [Boolean](../data_types/float.md) | `false` | Whether the item shows that it has this power.
+`negative`| [Boolean](../data_types/float.md) | `false` | Changes whether the tooltip is blue, or red.
 
 ### Examples:
 

--- a/docs/data_types/item_powers.md
+++ b/docs/data_types/item_powers.md
@@ -11,18 +11,18 @@ An [Object](object.md) which defines a power granted by an item.
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`power` | [Identifier](identifier.md) | *manditory* | ID of a Power.
-`slot` | [Slot](integer.md) | "mainhand" | Slot that the power is granted for.
-`hidden` | [Boolean](boolean.md) | false | Is the power visible on the item.
-`negative` | [Boolean](boolean.md) | false | Is the power a negative power.
+`power` | [Identifier](identifier.md) | | ID of a Power.
+`slot` | [Slot](integer.md) | `"mainhand"` | Slot that the power is granted for.
+`hidden` | [Boolean](boolean.md) | `false` | Is the power visible on the item.
+`negative` | [Boolean](boolean.md) | `false` | Is the power a negative power.
 
 ## Trinket Item Powers
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`power` | [Identifier](identifier.md) | *manditory* | ID of a Power.
-`hidden` | [Boolean](boolean.md) | false | Is the power visible on the item.
-`negative` | [Boolean](boolean.md) | false | Is the power a negative power.
+`power` | [Identifier](identifier.md) | | ID of a Power.
+`hidden` | [Boolean](boolean.md) | `false` | Is the power visible on the item.
+`negative` | [Boolean](boolean.md) | `false` | Is the power a negative power.
 
 
 ### Examples

--- a/docs/data_types/materials.md
+++ b/docs/data_types/materials.md
@@ -9,7 +9,7 @@ An [Object](object.md) used to define the properties of the block.
 Field                |                  Type               | Default | Description
 ---------------------|-------------------------------------|---------|-------------
 `liquid`             | [Boolean](../data_types/boolean.md) |  false  | (Not yet documented, if discovered please let me know on the discord)
-`solid`          	 | [Boolean](../data_types/boolean.md) |  true   | (Not yet documented, if discovered please let me know on the discord)
+`solid`          	   | [Boolean](../data_types/boolean.md) |  true   | (Not yet documented, if discovered please let me know on the discord)
 `blocks_movement`    | [Boolean](../data_types/boolean.md) |  true   | Stops the player from walking through the block.
 `blocks_light`       | [Boolean](../data_types/boolean.md) |  true   | Stops light from going through the block.
 `burnable`           | [Boolean](../data_types/boolean.md) |  false  | determines whether the block burns.

--- a/docs/data_types/render_layer.md
+++ b/docs/data_types/render_layer.md
@@ -7,6 +7,6 @@ Render layers are how the block is rendered.
 
   Name                |  Description
 ----------------------|-------------------------------
-  `solid`    	      |  Regular block rendering.
+  `solid`    	        |  Regular block rendering.
   `cutout`            |  Leaf-like blocks that have gaps in the texture.
-  `translucent`       |  Slime-like blocks that you can see through, but aren't clear.
+  `translucent`       |  Slime-like blocks that you can see through, but aren't fully clear.

--- a/docs/data_types/sounds.md
+++ b/docs/data_types/sounds.md
@@ -6,15 +6,15 @@ An [Object](object.md) used to define what sounds a block should make
 
 ### Fields:
 
-Field                |                  Type               |  Default  | Description
----------------------|-------------------------------------|-----------|-------------
-`pitch`              | [Sound](../data_types/sound.md)     |     1     | Sets the pitch of the sound.
-`volume`             | [Sound](../data_types/sound.md)     |     1     | Sets the volume
-`break_sound`        | [Sound](../data_types/sound.md)     |*manditory*| The sound that plays when you break the block.
-`step_sound`         | [Sound](../data_types/sound.md)     |*manditory*| The sound that plays when you step on the block.
-`place_sound`        | [Sound](../data_types/sound.md)     |*manditory*| The sound that plays when you place the block.
-`hit_sound`          | [Sound](../data_types/sound.md)     |*manditory*| The sound that plays when you hit the block.
-`fall_sound`         | [Sound](../data_types/sound.md)     |*manditory*| The sound that plays when you fall on the block.
+Field                |          Type               |  Default  | Description
+---------------------|-----------------------------|-----------|-------------
+`pitch`              | [Integer](integer.md)       |    `1`    | Sets the pitch of the sound.
+`volume`             | [Integer](integer.md)       |    `1`    | Sets the volume
+`break_sound`        | [Identifier](identifier.md) |           | The sound that plays when you break the block.
+`step_sound`         | [Identifier](identifier.md) |           | The sound that plays when you step on the block.
+`place_sound`        | [Identifier](identifier.md) |           | The sound that plays when you place the block.
+`hit_sound`          | [Identifier](identifier.md) |           | The sound that plays when you hit the block.
+`fall_sound`         | [Identifier](identifier.md) |           | The sound that plays when you fall on the block.
 
 ### Examples:
 

--- a/docs/data_types/string.md
+++ b/docs/data_types/string.md
@@ -18,7 +18,7 @@ A simple text.
 
 ```json
 {
-	"type": "origins:execute_command",
+	"type": "apoli:execute_command",
 	"command": "give @s minecraft:iron_axe{display:{Name:'{\"text\":\"Brutal Axe\", \"italic\": false}'}}"
 }
 ```

--- a/docs/enchantment/curse.md
+++ b/docs/enchantment/curse.md
@@ -6,11 +6,11 @@ Type ID: `enchantment:curse`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`treasure` | [Boolean](../data_types/boolean.md) | false | Is this enchantment considered treasure?
-`target` | [Enchantment Target](../data_types/enchantment_target.md) | *breakable* | What type of item this will go on.
-`max_level` | [Render Layer](../data_types/render_layer.md) | *1* | The maximum level you can get with the enchantment.
-`rarity` | [Rarity](../data_types/rarity.md) | *very_rare* | Sets the rarity of the enchantment. Values: `common`, `uncommon`, `rare`, `very_rare`
-`blacklist` | [Array](../data_types/array.md) od [Identifier](../data_types/identifier.md) | *optional* | A list of enchantments that you cannot have with this.
+`treasure` | [Boolean](boolean.md) | `false` | Is this enchantment considered treasure?
+`target` | Enchantment Target (Undocumented) | `"breakable"` | What type of item this will go on.
+`max_level` | [Integer](../data_types/integer.md) | `1` | The maximum level you can get with the enchantment.
+`rarity` | [String](../data_types/string.md) | `"very_rare"` | Sets the rarity of the enchantment. Accepts `"common"`, `uncommon`, `rare` and `very_rare`
+`blacklist` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | A list of enchantments that you cannot have with this.
 
 ### Example Code
 

--- a/docs/enchantment/generic.md
+++ b/docs/enchantment/generic.md
@@ -6,11 +6,11 @@ Type ID: `enchantment:generic`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`treasure` | [Boolean](../data_types/boolean.md) | false | Is this enchantment considered treasure?
-`target` | [Enchantment Target](../data_types/enchantment_target.md) | *breakable* | What type of item this will go on.
-`max_level` | [Render Layer](../data_types/render_layer.md) | *1* | The maximum level you can get with the enchantment.
-`rarity` | [Rarity](../data_types/rarity.md) | *very_rare* | Sets the rarity of the enchantment. Values: `common`, `uncommon`, `rare`, `very_rare`
-`blacklist` | [Array](../data_types/array.md) od [Identifier](../data_types/identifier.md) | *optional* | A list of enchantments that you cannot have with this.
+`treasure` | [Boolean](boolean.md) | `false` | Is this enchantment considered treasure?
+`target` | Enchantment Target (Undocumented) | `"breakable"` | What type of item this will go on.
+`max_level` | [Integer](../data_types/integer.md) | `1` | The maximum level you can get with the enchantment.
+`rarity` | [String](../data_types/string.md) | `"very_rare"` | Sets the rarity of the enchantment. Accepts `"common"`, `uncommon`, `rare` and `very_rare`
+`blacklist` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | *optional* | A list of enchantments that you cannot have with this.
 
 ### Example Code
 

--- a/docs/entity_actions/change_stat.md
+++ b/docs/entity_actions/change_stat.md
@@ -8,9 +8,9 @@ Type ID: `ccpacks:change_stat`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`stat_bar` | [Identifier](../data_types/identifier.md) | *manditory* | ID of the power type that defines the stat bar. Must be a [Stat Bar](../power_types/stat_bar.md) which exists on the player.
-`change` | [Integer](../data_types/integer.md) | *manditory* | This value will be added to the resource (won't go below 0 or above 20).
-`operation` | [String](../data_types/string.md) | "add" | Determines if the action should add or set the value of the resource. Accepts `"add"` or `"set"`.
+`stat_bar` | [Identifier](../data_types/identifier.md) | | ID of the power type that defines the stat bar. Must be a [Stat Bar (Power Type)](../power_types/stat_bar.md) which exists on the player.
+`change` | [Integer](../data_types/integer.md) | | This value will be added to the resource. Range: 0-10.
+`operation` | [String](../data_types/string.md) | `"add"` | Determines if the action should add or set the value of the resource. Accepts `"add"` or `"set"`.
 
 ### Example
 ```json
@@ -20,4 +20,4 @@ Field  | Type | Default | Description
     "change": 1
 }
 ```
-This action adds 1 to the `example_pack:mana_bar` [Stat Bar](../power_types/stat_bar.md) power. (`data\namespace\powers\example.json`)
+This action adds 1 to the `example_pack:mana_bar` [Stat Bar (Power Type)](../power_types/stat_bar.md). (`data\namespace\powers\example.json`)

--- a/docs/entity_actions/open_choice_screen.md
+++ b/docs/entity_actions/open_choice_screen.md
@@ -8,13 +8,14 @@ Type ID: `ccpacks:open_choice_screen`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`choice_layer` | [Identifier](../data_types/identifier.md) | *manditory* | ID of the choice layer that the action will open.
+`choice_layer` | [Identifier](../data_types/identifier.md) | | ID of the choice layer that the action will open.
 
 ### Example
 ```json
 "entity_action": {
-  	"type": "ccpacks:open_choice_screen",
+  "type": "ccpacks:open_choice_screen",
 	"choice_layer": "example_pack:choice"
 }
 ```
-opens the `example_pack:choice` layer for the player.
+
+This example will open the `example_pack:choice` (`data/example_pack/choice_layers/choice.json`) choice layer for the player.

--- a/docs/entity_conditions/active_power_type.md
+++ b/docs/entity_conditions/active_power_type.md
@@ -9,8 +9,8 @@ Type ID: `ccpacks:active_power_type`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`power_type` | [Identifier](../data_types/identifier.md) | *manditory* | The namespace ID of the power type which will be checked to see if any are active.
-`blacklisted_powers` | [Array](../data_types/array.md) of [Identifier](../data_types/identifier.md) | *manditory* | The namespace IDs of powers that will be excluded from the check.
+`power_type` | [Identifier](../data_types/identifier.md) | | The namespaced ID of the power type which will be checked to see if any are active.
+`blacklisted_powers` | [Array](../data_types/array.md) of [Identifiers](../data_types/identifier.md) | | The namespaced IDs of powers that will be excluded from the check.
 
 
 ### Examples
@@ -23,4 +23,4 @@ Field  | Type | Default | Description
       ]
 }
 ```
-This will return true if the player has any elytra flight power that isnt "example:elytra_power".
+This will return true if the player has any elytra flight power that isn't "example:elytra_power".

--- a/docs/entity_conditions/check_stat.md
+++ b/docs/entity_conditions/check_stat.md
@@ -10,9 +10,9 @@ Type ID: `ccpacks:check_stat`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`stat_bar` | [Identifier](../data_types/identifier.md) | *manditory* | ID of the power type that defines the stat bar. Must be a [Stat Bar](../power_types/stat_bar.md) which exists on the player.
-`comparison` | [Comparison](https://origins.readthedocs.io/en/latest/types/data_types/comparison/) | "==" | How the value of the power that will be evaluated should be compared to the specified value.
-`compare_to` | [Integer](../data_types/integer.md) | 0 | The value to compare the value of the power that will be evaluated to.
+`stat_bar` | [Identifier](../data_types/identifier.md) | | ID of the power type that defines the stat bar. Must be a [Stat Bar (Power Type)](../power_types/stat_bar.md) which exists on the player.
+`comparison` | [Comparison](https://origins.readthedocs.io/en/latest/types/data_types/comparison/) | `"=="` | How the value of the power that will be evaluated should be compared to the specified value.
+`compare_to` | [Integer](../data_types/integer.md) | `0` | The value to compare the value of the power that will be evaluated to.
 
 ### Example
 ```json

--- a/docs/entity_conditions/equipped_trinket.md
+++ b/docs/entity_conditions/equipped_trinket.md
@@ -8,7 +8,7 @@ Type ID: `ccpacks:equipped_trinket`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`item_condition` | [Item Condition](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | *mandatory* | The items that are searched for in the trinket slots.
+`item_condition` | [Item Condition](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | | The items that are searched for in the trinket slots.
 
 ### Example
 ```json

--- a/docs/features/ore_gen.md
+++ b/docs/features/ore_gen.md
@@ -5,13 +5,13 @@ Type ID: `feature:ore_generation`
 
 ### Fields
 
-   Field   | Type | Default | Description
------------|------|---------|-------------
-`block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that will be created by the generation.
-`vein_size` | [Integer](../data_types/integer.md) | 9 | The amount of ore blocks to be made per vein.
-`veins_per_chunk` | [Integer](../data_types/integer.md) | 20 | The amount of veins in one chunk.
-`min_height` | [Integer](../data_types/integer.md) | 0 | The lowest Y value you can find the ore at.
-`max_height` | [Integer](../data_types/integer.md) | 64 | The highest Y value you can find the ore at.
+Field             | Type                                      | Default | Description
+------------------|-------------------------------------------|---------|-------------
+`block`           | [Identifier](../data_types/identifier.md) |         | The block that will be created by the generation.
+`vein_size`       | [Integer](../data_types/integer.md)       | `9`     | The amount of ore blocks to be made per vein.
+`veins_per_chunk` | [Integer](../data_types/integer.md)       | `20`    | The amount of veins in one chunk.
+`min_height`      | [Integer](../data_types/integer.md)       | `0`     | The lowest Y value you can find the ore at.
+`max_height`      | [Integer](../data_types/integer.md)       | `64`    | The highest Y value you can find the ore at.
 
 
 ### Example Code

--- a/docs/features/tree_gen.md
+++ b/docs/features/tree_gen.md
@@ -4,17 +4,17 @@ Type ID: `feature:tree`
 
 ### Fields
 
-   Field   | Type | Default | Description
------------|------|---------|-------------
-`log_block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that will be the log of the tree.
-`leaf_block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that will be the leaves of the tree.
-`sapling_block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that will be the sapling of the tree.
-`log_height` | [Integer](../data_types/integer.md) | 4 | The amount of logs tall that the tree is.
-`log_variance` | [Integer](../data_types/integer.md) | 2 | How many blocks the tree height can vary by.
-`leaf_radius` | [Integer](../data_types/integer.md) | 2 | The radius of the leaves on the tree.
-`leaf_offset` | [Integer](../data_types/integer.md) | 0 | The height offset for where the leaves are made.
-`leaf_height` | [Integer](../data_types/integer.md) | 3 | The amount of leaves tall the tree is.
-`chance_per_chunk` | [Integer](../data_types/integer.md) | 33 | the % chance of a tree appearing per chunk (0-100).
+  Field              | Type                                    | Default | Description
+-------------------|-------------------------------------------|---------|-------------
+`log_block`        | [Identifier](../data_types/identifier.md) |         | The block that will be the log of the tree.
+`leaf_block`       | [Identifier](../data_types/identifier.md) |         | The block that will be the leaves of the tree.
+`sapling_block`    | [Identifier](../data_types/identifier.md) |         | The block that will be the sapling of the tree.
+`log_height`       | [Integer](../data_types/integer.md)       | `4`     | The amount of logs tall that the tree is.
+`log_variance`     | [Integer](../data_types/integer.md)       | `2`     | How many blocks the tree height can vary by.
+`leaf_radius`      | [Integer](../data_types/integer.md)       | `2`     | The radius of the leaves on the tree.
+`leaf_offset`      | [Integer](../data_types/integer.md)       | `0`     | The height offset for where the leaves are made.
+`leaf_height`      | [Integer](../data_types/integer.md)       | `3`     | The amount of leaves tall the tree is.
+`chance_per_chunk` | [Integer](../data_types/integer.md)       | `33`    | the % chance of a tree appearing per chunk (0-100).
 
 ### Example Code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,16 +1,15 @@
-# Welcome
-Welcome to the documentation for the CCPacks mod!
+# Welcome to the documentation for the CCPacks Mod!
 
-This mod gives the developers the ability to create new Custom Content in minecraft, without needing to know java.
+This mod gives the developers the ability to create new Custom Content in Minecraft, without needing to know Java.
 
 Huge thanks to Apace, who created the libraries that allow CCPacks to have as many features as it does.
 
 
 # General information
 - All custom content supports the Apoli Power system!
-- These powers are identical to the powers used in the Origins Mod, but are granted via the use of items, blocks, and more.
+- These powers are identical to the powers used in the Origins Mod, but are granted via the use of items, blocks etc.
 - The Origins mod is not required for CCPacks to work, although using both mods together allows for more possibilities in both.
-- Check out our [discord server](https://discord.gg/QRbhVGN5Jn) for distributing and sharing your creations!
+- Check out our [Discord Server](https://discord.gg/QRbhVGN5Jn) for distributing and sharing your creations!
 
 ## Helpful links
 

--- a/docs/item/armor.md
+++ b/docs/item/armor.md
@@ -4,22 +4,22 @@ Type ID: `item:armor`
 
 ### Fields
 
-   Field   | Type | Default | Description
------------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *10* | How many uses the item has.
-`slot` | [String](../data_types/string.md) | *optional* | Which equipped item to execute the action on. One of: `"head"`, `"chest"`, `"legs"`, `"feet"`.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
+Field  | Type | Default | Description
+-------|------|---------|-------------
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `10` | How many hits the armor will endure before breaking.
+`slot` | [String](../data_types/string.md) | `"head"` | Which equipment slot the armor will be equipped in. Accepts `"head"`, `"chest"`, `"legs"`, `"feet"`.
+`item_group` | [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_colour` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
 `end_colour` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`texture` | [String](../data_types/string.md) | *mandatory* | The name of the image files used to texture the armor.
-`protection` | [Integer](../data_types/integer.md) | *0* | the amount of damage that a weapon does.
-`toughness` | [Integer](../data_types/integer.md) | *0* | the amount of damage that a weapon does.
-`knockback_resistance` | [Integer](../data_types/integer.md) | *0* | How fast you can swing the weapon.
-`enchantability` | [Integer](../data_types/integer.md) | *0* | How likely you are to get good enchantments.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`texture` | [String](../data_types/string.md) | | The name of the image files used to texture the armor.
+`protection` | [Integer](../data_types/integer.md) | `0` | the amount of damage that a weapon does.
+`toughness` | [Integer](../data_types/integer.md) | `0` | the amount of damage that a weapon does.
+`knockback_resistance` | [Integer](../data_types/integer.md) | `0` | How fast you can swing the weapon.
+`enchantability` | [Integer](../data_types/integer.md) | `0` | How likely you are to get good enchantments.
 `repair_item` | [Identifier](../data_types/identifier.md) | *optional* | The item used to repair this item.
 
 ### Example Code

--- a/docs/item/disc.md
+++ b/docs/item/disc.md
@@ -6,13 +6,13 @@ Type ID: `item:music_disc`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`comparator_output` | [Integer](../data_types/integer.md) | 1 | The signal strength a comparator outputs from this disc
-`sound` | [Identifier](../data_types/identifier.md) | *mandatory* | the sound event that the disc uses.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`item_group` | [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`comparator_output` | [Integer](../data_types/integer.md) | `1` | The signal strength a comparator outputs from this disc.
+`sound` | [Identifier](../data_types/identifier.md) | | the sound event that the disc uses.
 
 ### Example Code
 

--- a/docs/item/durable.md
+++ b/docs/item/durable.md
@@ -6,14 +6,14 @@ Type ID: `item:durable`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../../data_types/string) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *mandatory* | How many uses the item has.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
+`name` | [String](../../data_types/string) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `100` | How many uses the item has.
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_colour` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
 `end_colour` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
 
 ### Example Code
 

--- a/docs/item/dyeable.md
+++ b/docs/item/dyeable.md
@@ -6,12 +6,12 @@ Type ID: `item:dyeable`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../../data_types/string) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`max_count` | [Integer](../data_types/integer.md) | *64* | The maximum stack count for the item (Max: 64).
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
+`name` | [String](../../data_types/string) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`max_count` | [Integer](../data_types/integer.md) | `64` | The maximum stack count for the item (Max: 64).
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
 
 ### Example Code
 

--- a/docs/item/food.md
+++ b/docs/item/food.md
@@ -6,20 +6,20 @@ Type ID: `item:food`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`max_count` | [Integer](../data_types/integer.md) | *64* | The maximum stack count for the item.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`max_count` | [Integer](../data_types/integer.md) | `64` | The maximum stack count for the item.
 `item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`hunger` | [Integer](../data_types/integer.md) | *4* | how many hunger it fills up (1 = half a bar)
-`saturation` | [Float](../data_types/float.md) | *8f* | How many saturation points the food fills
-`meat` | [Boolean](../data_types/boolean.md) | *false* | Can it be fed to dogs?
-`always_edible` | [Boolean](../data_types/boolean.md) | *false* | Can you eat it even when full?
-`drinkable` | [Boolean](../data_types/boolean.md) | *false* | If true, makes you drink it as apposed to eating.
-`sound` | [Identifier](../data_types/identifier.md) | *false* | The sound you play while you are eating it
-`returns` | [Identifier](../data_types/identifier.md) | *false* | The item that this item returns when used.
-`eating_time` | [Integer](../data_types/integer.md) | *false* | The amount of time (in ticks) it takes to eat
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`hunger` | [Integer](../data_types/integer.md) | `4` | how many hunger it fills up (1 = half a bar).
+`saturation` | [Float](../data_types/float.md) | `8.0` | How many saturation points the food fills.
+`meat` | [Boolean](../data_types/boolean.md) | `false` | If set to true, you'll be able to use this item to feed dogs, and it will be identified as meat by the [Meat (Item Condition Type)](https://origins.readthedocs.io/en/latest/types/item_condition_types/meat).
+`always_edible` | [Boolean](../data_types/boolean.md) | `false` | If set to true, this item will always be edible, even with full hunger.
+`drinkable` | [Boolean](../data_types/boolean.md) | `false` | If true, makes you drink it as if it was milk or a potion.
+`sound` | [Identifier](../data_types/identifier.md) | `"entity.generic.eat"` | The sound that plays while you are eating the item.
+`returns` | [Identifier](../data_types/identifier.md) | *optional* | The item that this item returns when used.
+`eating_time` | [Integer](../data_types/integer.md) | `30` | The amount of time (in ticks) the item will take to eat.
 
 ### Example Code:
 

--- a/docs/item/generic.md
+++ b/docs/item/generic.md
@@ -6,12 +6,12 @@ Type ID: `item:generic`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`max_count` | [Integer](../data_types/integer.md) | *64* | The maximum stack count for the item.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`max_count` | [Integer](../data_types/integer.md) | `64` | The maximum stack count for the item.
 `item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
 
 ### Example Code
 

--- a/docs/item/pullback.md
+++ b/docs/item/pullback.md
@@ -6,16 +6,18 @@ Type ID: `item:pullback`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../../data_types/string) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *optional* | How many uses the item has.
+`name` | [String](../../data_types/string) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `1` | How many uses the item has.
 `item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
-`start_color` | [Colour](../data_types/colour.md) | *optional* | How many uses the item has.
-`end_color` | [Colour](../data_types/colour.md) | *optional* | How many uses the item has.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`entity_type` | [Entity Type](../data_types/integer.md) | *optional* | The entity fired when you finish pulling it back.
-`max_speed` | [Integer](../data_types/integer.md) | *64* | The maximum speed it will launch a projectile at.
+`start_color` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
+`end_color` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`entity_type` | [Identifier](../data_types/identifier.md) | *optional* | The entity fired when you finish pulling it back.
+`max_speed` | [Float](../data_types/float.md) | `3.0` | The maximum speed it will launch a projectile at.
+
+[//]: # "TODO: explain how the `max_speed` float works. How do you calculate the amount of time it takes to pullback the item depending on the speed?"
 
 ### Example Code
 

--- a/docs/item/shield.md
+++ b/docs/item/shield.md
@@ -6,17 +6,19 @@ Type ID: `item:shield`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *100* | How many uses the item has.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `100` | How many uses the item has.
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_colour` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
 `end_colour` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`cooldown` | [Integer](../data_types/integer.md) | *60* | How long the shield takes to be able to be used again when struck with an axe.
-`enchantability` | [Integer](../data_types/integer.md) | *0* | How likely you are to get good enchantments.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`cooldown` | [Integer](../data_types/integer.md) | `60` | How long the shield takes to be able to be used again when struck with an axe, in ticks.
+`enchantability` | [Integer](../data_types/integer.md) | `0` | How likely you are to get good enchantments.
 `repair_item` | [Identifier](../data_types/identifier.md) | *optional* | The item used to repair this item.
+
+[//]: # "TODO: Explain how the `enchantability` field works. Is it a percentage? Does it have a limit?"
 
 ### Example Code
 

--- a/docs/item/tools.md
+++ b/docs/item/tools.md
@@ -6,19 +6,19 @@ Type IDs: `item:axe`, `item:pickaxe`, `item:shovel`, `item:hoe`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *10* | How many uses the item has.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `100` | How many uses the item has.
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_colour` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
 `end_colour` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`mining_speed_multiplier` | [Float](../data_types/float.md) | *0* | (unknown, if you know, tell me on the discord)
-`attack_damage` | [Integer](../data_types/integer.md) | *0* | the amount of damage that a weapon does.
-`attack_speed` | [Integer](../data_types/integer.md) | *0* | How fast you can swing the weapon.
-`mining_level` | [Integer](../data_types/integer.md) | *optional* | doesn't actually do anything on swords.
-`enchantability` | [Integer](../data_types/integer.md) | *0* | How likely you are to get good enchantments.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`mining_speed_multiplier` | [Float](../data_types/float.md) | `0.0` | (unknown, if you know, tell me on the discord)
+`attack_damage` | [Integer](../data_types/integer.md) | `0` | the amount of damage that a weapon does.
+`attack_speed` | [Integer](../data_types/integer.md) | `0` | How fast you can swing the weapon.
+`mining_level` | [Integer](../data_types/integer.md) | `0` |
+`enchantability` | [Integer](../data_types/integer.md) | `0` | How likely you are to get good enchantments.
 `repair_item` | [Identifier](../data_types/identifier.md) | *optional* | The item used to repair this item.
 
 ### Example Code

--- a/docs/item/trinket.md
+++ b/docs/item/trinket.md
@@ -8,14 +8,14 @@ Type ID: `item:trinket`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../../data_types/string) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *optional* | How many uses the item has.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
+`name` | [String](../../data_types/string) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `1` | How many uses the item has.
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_color` | [Colour](../data_types/colour.md) | *optional* | How many uses the item has.
 `end_color` | [Colour](../data_types/colour.md) | *optional* | How many uses the item has.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
 
 ### Example Code
 

--- a/docs/item/weapons.md
+++ b/docs/item/weapons.md
@@ -6,17 +6,17 @@ Type ID: `item:sword`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`name` | [String](../data_types/string.md) | *optional* | Sets the items name.
-`lore` | [Array](../data_types/array.md) of [String](../data_types/string.md) | *optional* | Lines of text below an item.
-`item_powers` | [Array](../data_types/array.md) of [Item Power](../data_types/item_power.md) | *optional* | The powers your item will have.
-`durability` | [Integer](../data_types/integer.md) | *10* | How many uses the item has.
-`item_group`| [Item Group](../data_types/item_groups.md) | `misc` | The tab you can find the item in.
+`name` | [String](../data_types/string.md) | *optional* | The display name of the item. Can be a literal string or a translation key. If none is given, it'll default to `item.namespace.path`.
+`lore` | [Array](../data_types/array.md) of [Strings](../data_types/string.md) | *optional* | Lines of text below an item.
+`item_powers` | [Array](../data_types/array.md) of [Item Powers](../data_types/item_power.md) | *optional* | The powers your item will have.
+`durability` | [Integer](../data_types/integer.md) | `100` | How many uses the item has.
+`item_group`| [Item Group](../data_types/item_groups.md) | `"misc"` | The tab you can find the item in.
 `start_colour` | [Colour](../data_types/colour.md) | *optional* | The start colour gradient of the Durability bar.
 `end_colour` | [Colour](../data_types/colour.md) | *optional* | The end colour gradient of the Durability bar.
-`fuel_tick` | [Integer](../data_types/integer.md) | *optional* | How long the item can smelt for in a furnace.
-`attack_speed` | [Integer](../data_types/integer.md) | *0* | How fast you can swing the weapon.
-`attack_damage` | [Integer](../data_types/integer.md) | *0* | the amount of damage that a weapon does.
-`enchantability` | [Integer](../data_types/integer.md) | *0* | How likely you are to get good enchantments.
+`fuel_tick` | [Integer](../data_types/integer.md) | `0` | How long the item can smelt for in a furnace.
+`attack_speed` | [Integer](../data_types/integer.md) | `0` | How fast you can swing the weapon.
+`attack_damage` | [Integer](../data_types/integer.md) | `0` | the amount of damage that a weapon does.
+`enchantability` | [Integer](../data_types/integer.md) | `0` | How likely you are to get good enchantments.
 `repair_item` | [Identifier](../data_types/identifier.md) | *optional* | The item used to repair this item.
 
 ### Example Code

--- a/docs/item_conditions/compare_durability.md
+++ b/docs/item_conditions/compare_durability.md
@@ -8,8 +8,8 @@ Type ID: `ccpacks:compare_durability`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`comparison` | [Comparison](https://origins.readthedocs.io/en/latest/types/data_types/comparison/) | "==" |  In what way to compare the durability the specified value.
-`compare_to` | [Integer](../data_types/integer.md) | 0 | The value to compare durability against.
+`comparison` | [Comparison](https://origins.readthedocs.io/en/latest/types/data_types/comparison/) | `"=="` |  In what way to compare the durability the specified value.
+`compare_to` | [Integer](../data_types/integer.md) | `0` | The value to compare durability against.
 
 ### Example
 

--- a/docs/item_groups/generic.md
+++ b/docs/item_groups/generic.md
@@ -1,12 +1,12 @@
 # Item Group
 
-TypeID: `item_group:generic`
+Type ID: `item_group:generic`
 
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`icon` | [Identifier](../data_types/identifier.md) | *mandatory* | The item that the tab will use for the icon.
+`icon` | [Identifier](../data_types/identifier.md) | | The item that the tab will use for the icon.
 `items` | [Array](../data_types/identifier.md) of [Identifier](../data_types/identifier.md) | *optional* | The items that are in the Item Group.
 
 ### Example Code

--- a/docs/item_groups/tabbed.md
+++ b/docs/item_groups/tabbed.md
@@ -1,6 +1,6 @@
 # Tabbed Item Group
 
-TypeID: `item_group:tabbed`
+Type ID: `item_group:tabbed`
 
 !!! note
 	the `*` in the fields section means that you can put anything as the field name.
@@ -9,7 +9,9 @@ TypeID: `item_group:tabbed`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`icon` | [Identifier](../data_types/identifier.md) | *mandatory* | The item that the tab will use for the icon.
+`icon` | [Identifier](../data_types/identifier.md) | | The item that the tab will use for the icon.
 `*` | [Item Group Generic](generic.md) | *optional* | The individual tabs use the same fields as `item_group:generic`
 
 ### Example Code
+
+**TODO**

--- a/docs/keybind.md
+++ b/docs/keybind.md
@@ -18,3 +18,5 @@ Type ID: `keybind:apoli`
 	"category": "example_pack_keybinds"
 }
 ```
+
+This example would create a keybind with the ID `key.ccpacks.winged_boost`, which would appear in the Keybind category `example_pack_keybinds`.

--- a/docs/layer_json.md
+++ b/docs/layer_json.md
@@ -9,7 +9,7 @@ Layer files need to be placed inside the `choice_layers` folder within your name
 Field  | Type | Default | Description
 -------|------|---------|-------------
 `choices` | [Array](data_types/array.md) of [Identifiers](data_types/identifier.md) | | Defines the choices that should be in this layer.
-`enabled` | [Boolean](data_types/boolean.md) | true | If set to false, this layer will be unavailable.
+`enabled` | [Boolean](data_types/boolean.md) | `true` | If set to false, this layer will be unavailable.
 
 ### Example
 

--- a/docs/mechanic_types.md
+++ b/docs/mechanic_types.md
@@ -1,7 +1,7 @@
 # Mechanic Types
 
 Mechanics are what grants functionality to blocks! Each mechanic has a type, specified with
-a `type` field in the JSON. Which type a mechanic is defines which other fields it requires and supports.
+a `type` field in the JSON. Which type a mechanic has defines which other fields it requires and supports.
 
 ## Regular types
 

--- a/docs/mechanic_types/on_land.md
+++ b/docs/mechanic_types/on_land.md
@@ -2,7 +2,7 @@
 
 [Mechanic Type](../mechanic_types.md).
 
-A Mechanic that is activated when a player falls onto the block
+A Mechanic that is activated when an entity falls onto the block
 
 Type ID: `ccpacks:on_land`
 
@@ -10,16 +10,17 @@ Type ID: `ccpacks:on_land`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`damage_multiplier` | [Float](../data_types/float.md) | 1.0 | Specifies how and if the stat bar is displayed with a bar on the HUD.
-`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on the player when they land on the block.
+`damage_multiplier` | [Float](../data_types/float.md) | `1.0` | Specifies how and if the stat bar is displayed with a bar on the HUD.
 `block_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block when it is landed on.
-`block_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the block action.
+`block_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked on the block in order to run the block action.
+`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on an entity when they land on the block.
 
 ### Example
 ```json
 {
-    "type": "ccpacks:on_land",
+  "type": "ccpacks:on_land",
 	"damage_multiplier": 0.0
 }
 ```
-This mechanic will create a block that negates all fall damage.
+
+This example will create a block that negates all fall damage.

--- a/docs/mechanic_types/on_neighbour_update.md
+++ b/docs/mechanic_types/on_neighbour_update.md
@@ -6,14 +6,17 @@ A Mechanic that is run when this block is updated (e.g. a block being placed nex
 
 Type ID: `ccpacks:on_neighbour_update`
 
+!!! note
+		This Mechanic type is called `on_neighbour_update`, not `on_neighbor_update`!
+
 ### Fields
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`neighbour_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the neighbouring block.
-`neighbour_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the neighbouring block action.
 `self_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block.
+`neighbour_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the neighbouring block.
 `self_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the self block action.
+`neighbour_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the neighbouring block action.
 
 ### Example
 ```json

--- a/docs/mechanic_types/on_step.md
+++ b/docs/mechanic_types/on_step.md
@@ -10,22 +10,22 @@ Type ID: `ccpacks:on_step`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on the player when they step on the block.
 `block_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block when it is stepped on.
+`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on an entity when they step on the block.
 `block_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the block action.
 
 ### Example
 ```json
 {
 	"type": "ccpacks:on_step",
-	"entity_action": {
-		"type": "origins:set_on_fire",
-		"duration": 5
-	},
 	"block_action": {
 		"type": "origins:set_block",
 		"block": "minecraft:air"
+	},
+	"entity_action": {
+		"type": "origins:set_on_fire",
+		"duration": 5
 	}
 }
 ```
-This mechanic will set the player on fire and remove the block.
+This mechanic will set the entity that steps on the block on fire and remove said block.

--- a/docs/mechanic_types/on_use.md
+++ b/docs/mechanic_types/on_use.md
@@ -10,8 +10,8 @@ Type ID: `ccpacks:on_use`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on the player when they interact with the block.
 `block_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block when it is interacted with.
+`entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | *optional* | The action to execute on the player when they interact with the block.
 `block_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the block action.
 
 ### Example

--- a/docs/mechanic_types/resource.md
+++ b/docs/mechanic_types/resource.md
@@ -2,7 +2,7 @@
 
 [Mechanic Type](../mechanic_types.md).
 
-Defines a resource for the block. Holds a persistent integer value, which can be modified by the [Change Resource](../entity_actions/change_stat.md) action and checked with the [Resource](../entity_conditions/check_stat.md) block condition.
+Defines a resource for the block. Holds a persistent integer value, which can be modified by the [Change Resource (Block Action Type)](../block_actions/change_resource.md) and checked with the [Resource (Block Condition Type)](../block_conditions/check_stat.md).
 
 Type ID: `ccpacks:resource`
 
@@ -10,17 +10,17 @@ Type ID: `ccpacks:resource`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`min` | [Integer](../data_types/integer.md) | 0 | The minimum value of the resource.
-`max` | [Integer](../data_types/integer.md) | 1 | The maximum value of the resource.
-`start_value` | [Integer](../data_types/integer.md) | 20 | The value of the resource when the block first gains this mechanic.
+`min` | [Integer](../data_types/integer.md) | `0` | The minimum value of the resource.
+`max` | [Integer](../data_types/integer.md) | `1` | The maximum value of the resource.
+`start_value` | [Integer](../data_types/integer.md) | `0` | The value of the resource when the block first gains this mechanic.
 
 ### Example
 ```json
 {
-    "type": "ccpacks:resource",
+	"type": "ccpacks:resource",
 	"min": 0,
 	"max": 100,
-    "start_value": 20
+	"start_value": 20
 }
 ```
-This mechanic is a resource, which starts at a value of 20.
+This example will create a resource with a minimum value of 0, maximum value of 1 and a starting value of 20.

--- a/docs/mechanic_types/tick.md
+++ b/docs/mechanic_types/tick.md
@@ -10,9 +10,9 @@ Type ID: `ccpacks:tick`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`interval` | [Integer](../data_types/integer.md) | 1 | Interval of ticks between subsequent executions of the specified actions. Must be a value of at least 1.
+`interval` | [Integer](../data_types/integer.md) | `1` | Interval of ticks between subsequent executions of the specified actions. Must be at least 1.
 `block_action` | [Block Action Types](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block that has the power each interval.
-`block_condition` | [Block Condition Types](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the block action.
+`block_condition` | [Block Condition Types](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked on the block in order to run the block action.
 
 ### Example
 ```json
@@ -28,4 +28,4 @@ Field  | Type | Default | Description
 	}
 }
 ```
-This mechanic will create an explosion at the block every 5 seconds (100 ticks).
+This example mechanic will create a non-destructive explosion at the block every 5 seconds (100 ticks).

--- a/docs/mechanic_types/triggerable.md
+++ b/docs/mechanic_types/triggerable.md
@@ -10,18 +10,18 @@ Type ID: `ccpacks:triggerable`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`neighbour_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the neighbouring block.
-`neighbour_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the neighbouring block action.
 `self_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the block.
 `self_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the self block action.
+`neighbour_action` | [Block Action Type](https://origins.readthedocs.io/en/latest/types/block_action_types/) | *optional* | The action to execute on the neighbouring block.
+`neighbour_condition` | [Block Condition Type](https://origins.readthedocs.io/en/latest/types/block_condition_types/) | *optional* | The condition to checked in order to run the neighbouring block action.
 
 ### Example
 ```json
 {
 	"type": "ccpacks:triggerable",
 	"self_action": {
-		"type": "origins:execute_command",
-		"command": "summon minecraft:item ~ ~ ~ {Item:{id:\"minecraft:wheat\",Count:1}}"
+		"type": "origins:spawn_entity",
+		"command": "summon minecraft:item ~ ~1 ~ {Item:{id:\"minecraft:wheat\",Count:1}}"
 	},
 	"self_condition": {
 		"type": "origins:light_level",
@@ -31,4 +31,4 @@ Field  | Type | Default | Description
 	}
 }
 ```
-This mechanic will summon the wheat item once triggered if the light is above 10.
+This example  mechanic will summon a wheat item above the block once it is triggered if the block's light level is above 10.

--- a/docs/particle/emissive.md
+++ b/docs/particle/emissive.md
@@ -1,15 +1,15 @@
-# Particles
+# Emissive Particles
 
-Type ID: `particle:emmisive`
+Type ID: `particle:emissive`
 
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`colour` | [Colour](../data_types/colour.md) | (1,1,1,1) | Determines the particles colour.
-`size` | [Float](../data_types/float.md) | 0.25 | How large the particle is.
-`max_age` | [Integer](../data_types/integer.md) | 100 | How long the particle last for (in ticks).
-`collides_with_world` | [Boolean](../data_types/boolean.md) | false | Does the particle collide with the world?
+`colour` | [Colour](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | Determines the particles colour.
+`size` | [Float](../data_types/float.md) | `0.25` | How large the particle is.
+`max_age` | [Integer](../data_types/integer.md) | `100` | How long the particle will last for (in ticks).
+`collides_with_world` | [Boolean](../data_types/boolean.md) | `false` | If set to true, the particle will have collisions.
 
 ### Example Code
 

--- a/docs/particle/generic.md
+++ b/docs/particle/generic.md
@@ -1,15 +1,15 @@
-# Particles
+# Generic Particles
 
 Type ID: `particle:generic`
 
 ### Fields
 
-   Field   | Type | Default | Description
+Field   | Type | Default | Description
 -----------|------|---------|-------------
-`colour` | [Colour](../data_types/colour.md) | (1,1,1,1) | Determines the particles colour.
-`size` | [Float](../data_types/float.md) | 0.25 | How large the particle is.
-`max_age` | [Integer](../data_types/integer.md) | 100 | How long the particle last for (in ticks).
-`collides_with_world` | [Boolean](../data_types/boolean.md) | false | Does the particle collide with the world?
+`colour` | [Colour](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | Determines the particles colour.
+`size` | [Float](../data_types/float.md) | `0.25` | How large the particle is.
+`max_age` | [Integer](../data_types/integer.md) | `100` | How long the particle will last for (in ticks).
+`collides_with_world` | [Boolean](../data_types/boolean.md) | `false` | If set to true, the particle will have collisions.
 
 ### Example Code
 

--- a/docs/portal/horizontal.md
+++ b/docs/portal/horizontal.md
@@ -1,13 +1,15 @@
-# Dimension Portals
+# Horizontal Dimension Portals
+
+Type ID: `portal:horizontal`
 
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that the portal is made out of.
+`block` | [Identifier](../data_types/identifier.md) | | The block that the portal is made out of.
 `ignition_item` | [Identifier](../data_types/identifier.md) | `minecraft:flint_and_steel` | The item used to ignite the portal with.
 `dimension` | [Identifier](../data_types/identifier.md) | `minecraft:the_end` | The dimension that the portal takes you to.
-`colour` | [Colour Holder](../data_types/colour.md) | (1,1,1,1) | The colour of the portal.
+`colour` | [Colour Holder](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | The colour of the portal.
 
 ### Example Code
 
@@ -18,9 +20,9 @@
 	"ignition_item": "minecraft:heart_of_the_sea",
 	"dimension": "minecraft:the_end",
 	"colour": {
-		"red": 37,
-		"green": 25,
-		"blue": 51
+		"red": 0.145,
+		"green": 0.098,
+		"blue": 0.2
 	}
 }
 ```

--- a/docs/portal/vertical.md
+++ b/docs/portal/vertical.md
@@ -1,13 +1,15 @@
-# Dimension Portals
+# Vertical Dimension Portals
+
+Type ID: `portal:vertical`
 
 ### Fields
 
-   Field   | Type | Default | Description
+  Field   | Type | Default | Description
 -----------|------|---------|-------------
-`block` | [Identifier](../data_types/identifier.md) | *mandatory* | The block that the portal is made out of.
+`block` | [Identifier](../data_types/identifier.md) | | The block that the portal is made out of.
 `ignition_item` | [Identifier](../data_types/identifier.md) | `minecraft:flint_and_steel` | The item used to ignite the portal with.
 `dimension` | [Identifier](../data_types/identifier.md) | `minecraft:the_end` | The dimension that the portal takes you to.
-`colour` | [Colour Holder](../data_types/colour.md) | (1,1,1,1) | The colour of the portal.
+`colour` | [Colour Holder](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | The colour of the portal.
 
 ### Example Code
 
@@ -18,9 +20,9 @@
 	"ignition_item": "minecraft:heart_of_the_sea",
 	"dimension": "minecraft:the_end",
 	"colour": {
-		"red": 37,
-		"green": 25,
-		"blue": 51
+		"red": 0.145,
+		"green": 0.098,
+		"blue": 0.2
 	}
 }
 ```

--- a/docs/power_types/action_on_projectile_land.md
+++ b/docs/power_types/action_on_projectile_land.md
@@ -1,4 +1,4 @@
-# Action On Being Used
+# Action On Projectile Land
 
 [Power Type](../power_types.md)
 
@@ -19,15 +19,15 @@ Field | Type | Default | Description
 ### Example
 ```json
 {
-    "type": "apoli:action_on_projectile_land",
-    "block_action": {
+	"type": "apoli:action_on_projectile_land",
+	"block_action": {
 		"type": "apoli:set_block",
 		"block": "minecraft:diamond_block"
 	},
-    "block_condition": {
-        "type": "apoli:block",
+	"block_condition": {
+		"type": "apoli:block",
 		"block": "minecraft:coal_block"
-    }
+	}
 }
 ```
-When any projectile lands, if the block it lands on is a coal block, turn it into a diamond block. 
+When any projectile lands, if the block it lands on is a coal block, turn it into a diamond block.

--- a/docs/power_types/bind_item.md
+++ b/docs/power_types/bind_item.md
@@ -10,7 +10,28 @@ Type ID: `ccpacks:bind_item`
 
 Field | Type | Default | Description
 ------|------|---------|------------
-`item_condition` | [Item Condition Type](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | _optional_ | If specified, only make the items that fulfill the specified item condition type are unable to leave the players inventory.
-`slots` | [Array](../data_types/array.md) of [Integers](../data_types/integer.md) | _optional_ | If specified, only make the items that are in the listed inventory slots are unable to leave the players inventory. See [Positioned Item Stack Slots](https://origins.readthedocs.io/en/latest/misc/extras/positioned_item_stack_slots/) for possible values.
+`item_condition` | [Item Condition Type](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | _optional_ | If specified, only make the items that fulfill the specified item condition are unable to leave the players inventory.
+`prevent_use_condition` | [Item Condition Type](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | _optional_ | If specified, it won't let the player use the items that fulfill the specified item condition.
+`slots` | [Array](../data_types/array.md) of [Integers](../data_types/integer.md) | _optional_ | If specified, only make the items that are in the listed inventory slots are unable to leave the players inventory. See the "Item Stack Slot" column of [Positioned Item Stack Slots](https://origins.readthedocs.io/en/latest/misc/extras/positioned_item_stack_slots/) for possible values.
 
 ### Example
+
+```json
+{
+	"type": "ccpacks:bind_item",
+	"item_condition": {
+		"type": "apoli:ingredient",
+		"ingredient": {
+			"item": "minecraft:trident"
+		}
+	},
+	"prevent_use_condition": {
+		"type": "apoli:ingredient",
+		"ingredient": {
+			"item": "minecraft:trident"
+		}
+	}
+}
+```
+
+This example would make it so that any trident that enters your inventory can't leave it until death, and can't be thrown

--- a/docs/power_types/item_use.md
+++ b/docs/power_types/item_use.md
@@ -2,7 +2,7 @@
 
 [Power Type](../power_types.md).
 
-This power uses the existing item interaction system in minecraft to execute actions. which means that when used, the actions wont happen if something of higher priority occurs (for example opening a chest).
+This power uses the existing item interaction system in Minecraft to execute actions. which means that when used, the actions won't happen if something of higher priority occurs (for example opening a chest).
 
 Type ID: `ccpacks:item_use`
 
@@ -10,7 +10,7 @@ Type ID: `ccpacks:item_use`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`cooldown` | [Integer](../data_types/integer.md) | 0 | Sets a cooldown on the item (Similar to ender pearl cooldowns).
+`cooldown` | [Integer](../data_types/integer.md) | `0` | Sets a cooldown on the item (Similar to ender pearl cooldowns).
 `entity_action` | [Entity Action Type](https://origins.readthedocs.io/en/latest/types/entity_action_types/) | _optional_ | The entity action to be executed on the player if specified.
 `item_action` | [Item Action Type](https://origins.readthedocs.io/en/latest/types/item_action_types/) | _optional_ | The item action to be executed if specified.
 `item_condition` | [Item Condition Type](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | _optional_ | If specified, only execute the action if the item condition is fulfilled.
@@ -18,29 +18,29 @@ Field  | Type | Default | Description
 ### Example
 ```json
 {
-    "type": "ccpacks:item_use",
-    "cooldown": 20,
+	"type": "ccpacks:item_use",
+	"cooldown": 20,
 	"item_action": {
-        "type": "apoli:damage",
-        "amount": 1
-    },
-    "item_condition": {
-        "type": "ccpacks:compare_durability",
-        "comparison": ">",
-        "compare_to": 1
-    },
-    "entity_action": {
-        "type": "ccpacks:change_stat",
-        "stat_bar": "example_pack:mana_bar",
-        "change": -2,
-        "operation": "add"
-    },
-    "condition": {
-        "type": "ccpacks:check_stat",
-        "stat_bar": "example_pack:mana_bar",
-        "comparison": ">=",
-        "compare_to": 2
-    }
+		"type": "apoli:damage",
+		"amount": 1
+	},
+	"item_condition": {
+		"type": "ccpacks:compare_durability",
+		"comparison": ">",
+		"compare_to": 1
+	},
+	"entity_action": {
+		"type": "ccpacks:change_stat",
+		"stat_bar": "example_pack:mana_bar",
+		"change": -2
+	},
+	"condition": {
+		"type": "ccpacks:check_stat",
+		"stat_bar": "example_pack:mana_bar",
+		"comparison": ">=",
+		"compare_to": 2
+	}
 }
 ```
-This power is in the example pack, attached to the kunzite_staff. When the item is used, it damages the item, if its durability is greater than 1. and it also removes from the players mana, if that is also not empty.
+
+This power is in the example pack, attached to the `kunzite_staff`. When the item is used, it damages the item, if its durability is greater than 1. and it also removes from the players mana, if that is also not empty.

--- a/docs/power_types/stat_bar.md
+++ b/docs/power_types/stat_bar.md
@@ -2,7 +2,7 @@
 
 [Power Type](../power_types.md).
 
-Defines a stat bar for the player. Basically holds a persistent integer value between 0, and 20, which can be modified by the [Change Stat](../entity_actions/change_stat.md) action and checked with the [Check Stat](../entity_conditions/check_stat.md) player condition.
+Defines a stat bar for the player. Basically holds a persistent integer value between 0, and 20, which can be modified by the [Change Stat (Entity Action Type)](../entity_actions/change_stat.md) and checked with the [Check Stat (Entity Condition Type)](../entity_conditions/check_stat.md).
 
 Type ID: `ccpacks:stat_bar`
 
@@ -10,8 +10,8 @@ Type ID: `ccpacks:stat_bar`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`hud_render` | [Stat Bar Hud Render](../data_types/stat_hud_render.md) | | Specifies how and if the stat bar is displayed with a bar on the HUD.
-`start_value` | [Integer](../data_types/integer.md) | 20 | The value of the resource when the player first gains this power.
+`hud_render` | [Stat Bar Hud Render](../data_types/hud_render.md) | | Specifies how and if the stat bar is displayed with a bar on the HUD.
+`start_value` | [Integer](../data_types/integer.md) | `20` | The value of the resource when the player first gains this power.
 
 ### Example
 ```json
@@ -29,4 +29,5 @@ Field  | Type | Default | Description
     "description": "You can use mana with your magical staff to activate its powers."
 }
 ```
-This power is a stat bar, which creates a bar of the given texture that is already completely filled.
+
+This example is a stat bar, which creates a bar of the given texture that is already completely filled.

--- a/docs/power_types/toggle.md
+++ b/docs/power_types/toggle.md
@@ -2,7 +2,7 @@
 
 [Power Type](../power_types.md).
 
-A custom version of the Apoli [Toggle](https://origins.readthedocs.io/en/latest/types/power_types/toggle/)
+A custom version of Apoli [Toggle (Power Type)](https://origins.readthedocs.io/en/latest/types/power_types/toggle/)
 
 Type ID: `ccpacks:toggle`
 

--- a/docs/power_types/use_as_bundle.md
+++ b/docs/power_types/use_as_bundle.md
@@ -10,7 +10,7 @@ Type ID: `ccpacks:use_as_bundle`
 
 Field  | Type | Default | Description
 -------|------|---------|-------------
-`hold_amount` | [Integer](../data_types/integer.md) | 64 | the amount of items you can store in the bundle.
+`hold_amount` | [Integer](../data_types/integer.md) | `64` | the amount of items you can store in the bundle.
 `item_condition` | [Item Condition Type](https://origins.readthedocs.io/en/latest/types/item_condition_types/) | _optional_ | Items that fulfil this condition, will be bundle-like.
 
 
@@ -20,7 +20,7 @@ Field  | Type | Default | Description
 	"type": "ccpacks:use_as_bundle",
 	"hold_amount": 64,
 	"item_condition": {
-		"type": "origins:nbt",
+		"type": "apoli:nbt",
 		"nbt": "{isBundle:1b}"
 	}
 }

--- a/docs/projectile.md
+++ b/docs/projectile.md
@@ -6,12 +6,12 @@ Type ID: `projectile:item`
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`damage` | [Integer](../data_types/integer.md) | 0 | The damage that the projectile will deal.
-`height` | [Float](../data_types/float.md) | 0.25 | The height of the projectile.
-`width` | [Float](../data_types/float.md) | 0.25 | The width of the projectile.
-`gravity` | [Float](../data_types/float.md) | 0.03 | The gravity that the projectile will have.
-`base_item` | [Identifier](../data_types/identifier.md) | *manditory* | The item that the projectile will look like.
-`damage_source` | [Damage Source](../data_types/damage_source.md) | *manditory* | The damage source that the projectile deals.
+`damage` | [Integer](../data_types/integer.md) | `0` | The damage that the projectile will deal.
+`height` | [Float](../data_types/float.md) | `0.25` | The height of the projectile.
+`width` | [Float](../data_types/float.md) | `0.25` | The width of the projectile.
+`gravity` | [Float](../data_types/float.md) | `0.03` | The gravity that the projectile will have.
+`base_item` | [Identifier](../data_types/identifier.md) | | The item that the projectile will look like.
+`damage_source` | [Damage Source](../data_types/damage_source.md) | | The damage source that the projectile deals.
 
 ### Example Code
 

--- a/docs/sound_event.md
+++ b/docs/sound_event.md
@@ -1,9 +1,11 @@
 # Sound Events
 
+[//]: # "TODO: Explain the deal with Sound Events being dumb or smth"
+
 ### Example Code
 
 ```json
 {
-	type": "sound:sound_event"
+	"type": "sound:sound_event"
 }
 ```

--- a/docs/status_effect/beneficial.md
+++ b/docs/status_effect/beneficial.md
@@ -1,10 +1,12 @@
 # Beneficial Status Effect
 
+Type ID: `"status_effect:beneficial"`
+
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`colour` | [Colour Holder](../data_types/colour.md) | (1,1,1,1) | The colours used in the potions particle effects. The alpha value doesnt effect this.
+`colour` | [Colour Holder](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | The colours used in the status effect's particles. The alpha value doesn't affect this.
 
 Add functionality using [Power Types](https://origins.readthedocs.io/en/latest/types/power_types/) and [Universal Powers](../universal_powers.md)
 

--- a/docs/status_effect/harmful.md
+++ b/docs/status_effect/harmful.md
@@ -1,10 +1,13 @@
 # Harmful Status Effect
 
+Type ID: `"status_effect:harmful"`
+
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`colour` | [Colour Holder](../data_types/colour.md) | (1,1,1,1) | The colours used in the potions particle effects. The alpha value doesnt effect this.
+`colour` | [Colour Holder](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | The colours used in the status effect's particles. The alpha value doesn't affect this.
+
 
 Add functionality using [Power Types](https://origins.readthedocs.io/en/latest/types/power_types/) and [Universal Powers](../universal_powers.md)
 

--- a/docs/status_effect/neutral.md
+++ b/docs/status_effect/neutral.md
@@ -1,10 +1,12 @@
 # Neutral Status Effect
 
+Type ID: `"status_effect:neutral"`
+
 ### Fields
 
    Field   | Type | Default | Description
 -----------|------|---------|-------------
-`colour` | [Colour Holder](../data_types/colour.md) | (1,1,1,1) | The colours used in the potions particle effects. The alpha value doesnt effect this.
+colour` | [Colour Holder](../data_types/colour.md) | `{"red": 1, "green": 1, "blue": 1, "alpha": 1)` | The colours used in the status effect's particles. The alpha value doesn't affect this.
 
 Add functionality using [Power Types](https://origins.readthedocs.io/en/latest/types/power_types/) and [Universal Powers](../universal_powers.md)
 

--- a/docs/universal_powers.md
+++ b/docs/universal_powers.md
@@ -1,10 +1,15 @@
 ### Universal Powers
 
-Custom Content Packs allow you to use the same power system as origins (Apoli), with your custom content for greater variety. In order to use the universal power system. you make your power files as you would in origins. And then make the directories `/data/<namespace>/universal_powers/` and create a json file in there (it can be named anything)
-Then, in this file, you enter your powers, and entities, as shown in the following examples:
+Custom Content Packs allow you to use the same power system as Origins (Apoli), with your custom content for greater variety. In order to use the universal power system. you make your power files as you would in Origins. And then make the directories `/data/<namespace>/universal_powers/` and create a JSON file in there (it can be named anything)
+Then, in this file, you enter your powers, and entities.
+
+Fields  | Type | Default | Description
+--------|------|---------|-------------
+`powers` | [Array](data_types/array.md) of [Identifiers](data_types/identifier.md) | _optional_ | The namespace and IDs of the powers you want to give to all entities.
+`entity_entry` | [Object](data_types/object.md) | _optional_ | An object that accepts either an `entity` or a `tag` [Identifier](data_types/identifier.md). Cannot be both.
 
 ### Examples
-```
+```json
 {
 	"powers": [
 		"namespace:power_name",
@@ -17,7 +22,7 @@ Then, in this file, you enter your powers, and entities, as shown in the followi
 ```
 This example would apply the powers `namespace:power_name` and `namespace:power_name_2` to all players.
 
-```
+```json
 {
 	"powers": [
 		"namespace:power_name",
@@ -28,4 +33,4 @@ This example would apply the powers `namespace:power_name` and `namespace:power_
 	}
 }
 ```
-This example would apply the powers `namespace:power_name` and `namespace:power_name_2` to all entities in the tag `minecraft:skeletons`.
+This example would apply the powers `namespace:power_name` and `namespace:power_name_2` to all entities in the `minecraft:skeletons` Entity Type tag.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,14 +30,14 @@ nav:
         - Item Groups:
             - Generic: item_groups/generic.md
             - Tabbed: item_groups/tabbed.md
-        - Status Effects: 
+        - Status Effects:
             - Neutral: status_effect/neutral.md
             - Beneficial: status_effect/beneficial.md
             - Harmful: status_effect/harmful.md
         - Enchantments:
             - Generic: enchantment/generic.md
             - Curse: enchantment/curse.md
-        - Portals: 
+        - Portals:
             - Vertical: portal/vertical.md
             - Horizontal: portal/horizontal.md
         - Keybind: keybind.md
@@ -70,7 +70,7 @@ nav:
         - Data Types: data_types.md
         - Choice JSON: choice_json.md
         - Layer JSON: layer_json.md
-        
+
 
 theme:
   name: material
@@ -95,9 +95,9 @@ plugins:
       version: 8.6.4
       arguments:
           theme: 'neutral'
-          
+
 markdown_extensions:
     - admonition
-    
+
 extra_javascript:
     - https://unpkg.com/mermaid@8.7.0/dist/mermaid.min.js


### PR DESCRIPTION
This includes:

- Made more similar to the convention of the Origins wiki

- Added more in-line codeblocks

- Fixed many typos

- Added notes warning about the british differences in some types 
("Colour", "Neighbour" etc.)

- Removed all "*manditory*"s [sic] from defaults

- Used plurals for the hypertext of data types in arrays ("Array of 
Identifiers" instead of "Array of Identifier")

- Added some examples to types that didn't have them

- Fixed and reindented some examples that were broken (looking at you, 
`sound_event.md`)

- Fixed some hypertexts leading to 404 pages.

- Fixed the types of some fields being incorrect

- And more stuff I can't be bothered to remember :p